### PR TITLE
Expose master address

### DIFF
--- a/cmd/master/main.go
+++ b/cmd/master/main.go
@@ -104,8 +104,14 @@ func main() {
 		fmt.Fprintln(w, strings.Join(addrs, "\n"))
 	})
 
+	http.HandleFunc("/master", func(w http.ResponseWriter, r *http.Request) {
+		mu.RLock()
+		defer mu.RUnlock()
+		addr := fmt.Sprintf("localhost:%d", *port)
+		fmt.Fprintln(w, addr)
+	})
+
 	addr := fmt.Sprintf(":%d", *port)
 	log.Printf("master listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
-
 }


### PR DESCRIPTION
The reason we do it because we intend to expose master and replicas for people to be able to put them behind their Proxies for usage. We intend to create our own proxy, but that will be for later